### PR TITLE
Use interop>=1.1.5 for iSeq support

### DIFF
--- a/projman_filler/__init__.py
+++ b/projman_filler/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """Johan Dahlberg"""
 __email__ = 'johan.dahlberg@medsci.uu.se'
-__version__ = '1.5.0'
+__version__ = '1.5.1'

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('README.md') as readme_file:
 requirements = [
     'Click>=6.0',
     'xmltodict',
-    'interop',
+    'interop>=1.1.5',
     'SQLAlchemy',
     'pymssql',
     'pandas'


### PR DESCRIPTION
This PR solves a problem where `projman_filler` would fail when trying to gather statistics for an iSeq run. This was caused by a bug in illumina/interop that has been fixed in v1.1.5. 