### PR TITLE
Implementing total_clusters_raw similar to as total_clusters_pf

### DIFF
--- a/projman_filler/interop_run_stats_parser.py
+++ b/projman_filler/interop_run_stats_parser.py
@@ -131,7 +131,7 @@ class InteropRunStatsParser(RunStatsParserInterface):
                     # These are the same for the lane across all reads
                     total_clusters_pf = row['Reads Pf']
                     # These must be summed
-                    total_clusters_raw += row['Reads']
+                    total_clusters_raw = row['Reads']
             lanes.append(Lane(l, total_clusters_raw, total_clusters_pf))
         return lanes
 

--- a/projman_filler/interop_run_stats_parser.py
+++ b/projman_filler/interop_run_stats_parser.py
@@ -114,7 +114,6 @@ class InteropRunStatsParser(RunStatsParserInterface):
     def _get_conversion_results(self) -> list:
         ar = iop.summary(self._run_metrics, 'Lane')
         df = pd.DataFrame(ar)
- 
         # Get statistics per-lane
         n_lanes = self._run_summary.lane_count()
         lanes = []

--- a/tests/test_interop_run_stats_parser.py
+++ b/tests/test_interop_run_stats_parser.py
@@ -11,18 +11,18 @@ class TestRunStatsParsers(unittest.TestCase):
     def test_interop_standardize_read_numbers(self):
         runfolder = "tests/resources/200624_A00834_0183_BHMTFYTINY"
 
-        non_index_reads = [0, 2, 3]
+        non_index_reads = [0]
         iop = InteropRunStatsParser(runfolder, non_index_reads)
         remapped = iop._standardize_read_numbers()
-        expected = {1: 0, 2: 2, 3: 3}
+        expected = {1: 0}
         self.assertEqual(remapped, expected)
 
         reads = iop.get_reads()
-        expected = [1, 2, 3]
+        expected = [1]
         self.assertEqual(reads, expected)
 
     def test_lanes_total_clusters(self):
-        non_index_reads = [0, 2, 3]
+        non_index_reads = [0]
         runfolder = "tests/resources/200624_A00834_0183_BHMTFYTINY"
         iop = InteropRunStatsParser(runfolder, non_index_reads)
         for lane in iop._conversion_results:
@@ -33,20 +33,12 @@ class TestRunStatsParsers(unittest.TestCase):
         """
         Verify that 'Reads' and 'Reads Pf' are consistently the same across all reads within the same lane
         """
-        non_index_reads = [0, 2, 3]
+        non_index_reads = [0]
         runfolder = "tests/resources/200624_A00834_0183_BHMTFYTINY"
         iop = InteropRunStatsParser(runfolder, non_index_reads)
         
-
-        data = {
-                'ReadNumber': [1, 1, 2, 2, 3, 3],
-                'IsIndex': [78, 78, 89, 89, 89, 89],
-                'Lane': [1, 2, 1, 2, 1, 2],
-                'Reads': [638337024.0] * 6,
-                'Reads Pf': [532464320.0, 530917568.0] * 3,
-            }
-
-        df = pd.DataFrame(data)
+        interop_lane_summary = interop.summary(iop._run_metrics, 'Lane')
+        df = pd.DataFrame(interop_lane_summary)
 
         for lane_index, (lane, rows) in enumerate(df.groupby('Lane')):
             rows = rows.reset_index()
@@ -72,7 +64,6 @@ class TestRunStatsParsers(unittest.TestCase):
                     f"Mismatch in total_clusters_raw for lane {lane}"
                     )
                 
-
 if __name__ == '__main__':
     unittest.main()
 

--- a/tests/test_interop_run_stats_parser.py
+++ b/tests/test_interop_run_stats_parser.py
@@ -2,7 +2,10 @@ import unittest
 from unittest.mock import MagicMock
 from projman_filler.interop_run_stats_parser import InteropRunStatsParser
 from interop import py_interop_run, py_interop_run_metrics, py_interop_summary
+import pandas as pd
 import interop
+from projman_filler.lane import Lane
+
 
 class TestRunStatsParsers(unittest.TestCase):
     def test_interop_standardize_read_numbers(self):
@@ -26,5 +29,50 @@ class TestRunStatsParsers(unittest.TestCase):
             assert lane._total_clusters_pf is not None and lane._total_clusters_pf != 0
             assert lane._total_clusters_raw is not None and lane._total_clusters_raw != 0
 
+    def test_clusters_same_across_lanes(self):
+        """
+        Verify that 'Reads' and 'Reads Pf' are consistently the same across all reads within the same lane
+        """
+        non_index_reads = [0, 2, 3]
+        runfolder = "tests/resources/200624_A00834_0183_BHMTFYTINY"
+        iop = InteropRunStatsParser(runfolder, non_index_reads)
+        
+
+        data = {
+                'ReadNumber': [1, 1, 2, 2, 3, 3],
+                'IsIndex': [78, 78, 89, 89, 89, 89],
+                'Lane': [1, 2, 1, 2, 1, 2],
+                'Reads': [638337024.0] * 6,
+                'Reads Pf': [532464320.0, 530917568.0] * 3,
+            }
+
+        df = pd.DataFrame(data)
+
+        for lane_index, (lane, rows) in enumerate(df.groupby('Lane')):
+            rows = rows.reset_index()
+            # Assert all 'Reads' and 'Reads Pf' values are consistent within the lane
+            assert rows['Reads'].nunique() == 1, (
+                    f"Inconsistent 'Reads' in lane {lane}"
+                    )
+            assert rows['Reads Pf'].nunique() == 1, (
+                    f"Inconsistent 'Reads Pf' in lane {lane}"
+                    )
+
+            # These are the same for the lane across all reads
+            total_clusters_pf = rows.at[0, 'Reads Pf']
+            total_clusters_raw = rows.at[0, 'Reads']
+            
+            
+            # Compare with InteropRunStatsParser results
+            lane_results = iop._conversion_results[lane_index]
+            assert lane_results._total_clusters_pf == total_clusters_pf, (
+                    f"Mismatch in total_clusters_pf for lane {lane}"
+                    )
+            assert lane_results._total_clusters_raw == total_clusters_raw, (
+                    f"Mismatch in total_clusters_raw for lane {lane}"
+                    )
+                
+
 if __name__ == '__main__':
     unittest.main()
+


### PR DESCRIPTION
Solves the bug found in this [confluence report](https://snpseq.atlassian.net/wiki/spaces/DATAOP/pages/3973971974/projman_filler+investigation+250514) where it was found that raw_reads shouldn't be summed up i.e total_clusters_raw is handled in the same way as total_clusters_pf