### PR TITLE
Make demultiplexer optional and olink_mode > demultiplexer

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+**Description**
+
+**Risk analysis**
+
+**Validation procedure**

--- a/projman_filler/__init__.py
+++ b/projman_filler/__init__.py
@@ -2,4 +2,4 @@
 
 """Top-level package for ProjMan Filler."""
 
-__version__ = '1.8.0'
+__version__ = '1.8.1-rc1'

--- a/projman_filler/app.py
+++ b/projman_filler/app.py
@@ -65,7 +65,7 @@ class App(object):
                                  demultiplexer, ch_config_path, force=False,
                                  atac_seq_mode=False, olink_mode=False):
         """
-        Inserts runfolder data into the specific database based on the specified 
+        Inserts runfolder data into the specific database based on the specified
             demultiplexer and mode.
 
         :param runfolder (str): Path to the runfolder directory.
@@ -78,18 +78,22 @@ class App(object):
         """
         flowcell_name = None
 
-        if demultiplexer == "bcl2fastq":
-            flowcell_name = self._handle_bcl2fastq(
-                runfolder, bcl2fastq_stats_dir, force, atac_seq_mode
-            )
-        elif olink_mode:
+        if olink_mode:
             print("Olink mode activated. Will read lane-level statistics from "
                   "InterOp files instead of bcl2fastq Stats.json.")
             return self.insert_olink_runfolder_into_db(runfolder, force)
-        else:
-            flowcell_name = self._handle_other_demultiplexer(
-               runfolder, demultiplexer, ch_config_path, force
+
+        match demultiplexer:
+            case "bcl2fastq":
+                flowcell_name = self._handle_bcl2fastq(
+                runfolder, bcl2fastq_stats_dir, force, atac_seq_mode
             )
+            case "bclconvert":
+                flowcell_name = self._handle_other_demultiplexer(
+               runfolder, demultiplexer, ch_config_path, force
+                )
+            case _:
+                raise ValueError(f"{demultiplexer} is not a supported demultiplexer")
 
         self.insert_flowcell_runfolder_into_db(runfolder, flowcell_name)
 
@@ -102,7 +106,7 @@ class App(object):
         :param force (bool): If True, existing flowcell data will be overwritten.
         :param atac_seq_mode (bool): If True, enables ATAC-seq specific processing.
 
-        :return flowcell_name (str): The flowcell name extracted from the bcl2fastq 
+        :return flowcell_name (str): The flowcell name extracted from the bcl2fastq
             statistics (after saving flowcel_lane and sample data in DB).
         """
         stats_path = os.path.join(runfolder, stats_dir)
@@ -119,7 +123,7 @@ class App(object):
             print("ATAC-seq mode activated. Will re-map read numbers according "
                   "to settings used by bcl2fastq.")
             non_index_reads = bcl2fastq_stats.get_non_index_reads()
-        
+
         interop = InteropRunStatsParser(runfolder, non_index_reads)
         lane_stats = calculate_lane_statistics(
             interop, flowcell_name, conversion_results
@@ -139,7 +143,7 @@ class App(object):
         Inserts runfolder data into the database using Olink-specific processing.
 
         :param runfolder (str): Path to the runfolder directory.
-        :param force (bool, optional): If True, existing flowcell data will be 
+        :param force (bool, optional): If True, existing flowcell data will be
             overwritten. Defaults to False.
         """
         interop = InteropRunStatsParser(runfolder)
@@ -166,7 +170,7 @@ class App(object):
         :param ch_config_path (Path): Path to the checkQC configuration file
         :param force (bool): If True, existing flowcell data will be overwritten.
 
-        :return flowcell_name (str): The flowcell name extracted from the runfolder 
+        :return flowcell_name (str): The flowcell name extracted from the runfolder
             (after saving flowcel_lane and sample data in DB).
         """
 

--- a/projman_filler/cli.py
+++ b/projman_filler/cli.py
@@ -18,28 +18,31 @@ from projman_filler import __version__ as projman_filler_version
 @click.option('--debug', is_flag=True)
 @click.option('--atac-seq-mode', is_flag=True)
 @click.option('--olink-mode', is_flag=True)
-@click.option('-b', '--bcl2fastq-stats', default="Unaligned/Stats", 
+@click.option('-b', '--bcl2fastq-stats', default="Unaligned/Stats",
     type=click.Path()
 )
-@click.option('-d', '--demultiplexer', default ="bcl2fastq", 
+@click.option('-d', '--demultiplexer',
     type=click.Choice(['bcl2fastq', 'bclconvert'])
 )
 @click.option(
     "--config",
-    default="/etc/arteria/checkqc_config/checkqc.config",
     type=click.Path(exists=True, dir_okay=False),
     help="Path to the checkQC configuration file",
 )
 @click.argument('runfolder', type=click.Path())
-def main(runfolder, force, atac_seq_mode, olink_mode, bcl2fastq_stats, 
+def main(runfolder, force, atac_seq_mode, olink_mode, bcl2fastq_stats,
          demultiplexer, config, debug):
-    """Console script for projman_filler."""
+
     print("projman_filler v{}".format(projman_filler_version))
+
+    if demultiplexer and olink_mode:
+        print("Warning: Both olink_mode and demultiplexer specified, olink_mode take precedence")
+
     try:
         db_connection_string = os.environ["PROJMAN_DB"]
         app = App(db_connection_string, debug)
         app.insert_runfolder_into_db(
-            runfolder, bcl2fastq_stats, demultiplexer, config, force=force, 
+            runfolder, bcl2fastq_stats, demultiplexer, config, force=force,
             atac_seq_mode=atac_seq_mode, olink_mode=olink_mode
         )
     except FlowcellAlreadyInDb:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,57 @@
+
+import os
+import unittest
+from unittest.mock import patch
+from click.testing import CliRunner
+
+from projman_filler.cli import main
+
+
+class TestCLI(unittest.TestCase):
+
+    @patch("projman_filler.app.App.insert_olink_runfolder_into_db")
+    def test_cli_prefers_olink_mode_even_if_demultiplexer_specified(
+        self, mock_insert_olink
+    ):
+        runner = CliRunner()
+
+        os.environ["PROJMAN_DB"] = "sqlite:///:memory:"
+
+        result = runner.invoke(
+            main,
+            [
+                "--demultiplexer", "bcl2fastq",
+                "--olink-mode",
+                "/path/to/runfolder"
+            ],
+            catch_exceptions=False,
+        )
+
+        self.assertEqual(result.exit_code, 0)
+
+        expected_warning = (
+            "Warning: Both olink_mode and demultiplexer specified, olink_mode take precedence"
+        )
+        self.assertIn(expected_warning, result.output)
+
+        mock_insert_olink.assert_called_once_with("/path/to/runfolder", False)
+
+
+    def test_no_olink_no_demultiplexer(
+        self
+    ):
+        runner = CliRunner()
+
+        os.environ["PROJMAN_DB"] = "sqlite:///:memory:"
+
+        with self.assertRaises(ValueError) as ctx:
+            runner.invoke(
+                main,
+                [
+                    "/path/to/runfolder"
+                ],
+                catch_exceptions=False
+            )
+
+        self.assertEqual(str(ctx.exception), "None is not a supported demultiplexer")
+


### PR DESCRIPTION
**Description**
This PR solves an issue where projman_filler would take the "bcl2fastq path" even if olink_mode was selected. The current implementation prints a warning if both demultiplexer and olink_mode is specified, but olink_mode takes precedence. 

**Risk analysis**
Unit tests pass, but the removed defaults could be assumed in snpseq_packs.

**Validation procedure**
Run olink_workflow in snpseq_packs. 
